### PR TITLE
Re-enable ssldir creation target for openssl install

### DIFF
--- a/bin/ruby-build
+++ b/bin/ruby-build
@@ -1120,7 +1120,7 @@ build_package_mac_openssl() {
   package_option openssl make -j 1
 
   # Use install_sw instead of install to skip building docs which is slow
-  MAKE_INSTALL_TARGET=install_sw build_package_standard "$@"
+  MAKE_INSTALL_TARGET="install_sw install_ssldirs" build_package_standard "$@"
 
   # Extract root certs from the system keychain in .pem format and rehash.
   local pem_file="$OPENSSLDIR/cert.pem"


### PR DESCRIPTION
Prior commit attempts to shorten install by omitting documentation install,
however an additional target is needed to get the conf dirs for capturing the
PEMs et al.

Solves issue mentioned in [discussion 1972](https://github.com/rbenv/ruby-build/discussions/1972).

